### PR TITLE
Rename ConfigPlanillas class

### DIFF
--- a/app/Clases/Planilla/ConfigPlanillas.php
+++ b/app/Clases/Planilla/ConfigPlanillas.php
@@ -12,7 +12,7 @@ namespace ATS\Clases\Planilla;
 
 use Illuminate\Support\Facades\Config;
 
-class ConfigPlanillass
+class ConfigPlanillas
 {
     /**
      * @var array

--- a/app/Http/Middleware/VerifyIndicadores.php
+++ b/app/Http/Middleware/VerifyIndicadores.php
@@ -3,7 +3,7 @@
 namespace ATS\Http\Middleware;
 
 use ATS\Clases\Indicador\IndicadoresPlanilla;
-use ATS\Clases\Planilla\ConfigPlanillass;
+use ATS\Clases\Planilla\ConfigPlanillas;
 use ATS\Exceptions\IndicadoresException;
 use Closure;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -22,7 +22,7 @@ class VerifyIndicadores
      */
     public function handle($request, Closure $next)
     {
-        $conf = new ConfigPlanillass();
+        $conf = new ConfigPlanillas();
         $indicadores = new IndicadoresPlanilla($request->planilla);
         if (! $this->CheckStatus($indicadores,$conf)){
             throw new IndicadoresException();
@@ -32,10 +32,10 @@ class VerifyIndicadores
 
     /**
      * @param IndicadoresPlanilla $indicadores
-     * @param ConfigPlanillass $conf
+     * @param ConfigPlanillas $conf
      * @return bool
      */
-    public function CheckStatus(IndicadoresPlanilla $indicadores, ConfigPlanillass $conf){
+    public function CheckStatus(IndicadoresPlanilla $indicadores, ConfigPlanillas $conf){
         return $indicadores->countInd() === $conf->nro_indicadores();
     }
 


### PR DESCRIPTION
## Summary
- rename `ConfigPlanillass` class and file to `ConfigPlanillas`
- update middleware references
- regenerate Composer autoload files

## Testing
- `php -l app/Clases/Planilla/ConfigPlanillas.php`
- `php -l app/Http/Middleware/VerifyIndicadores.php`
- `composer dump-autoload --no-scripts`
- `composer install --no-interaction` *(fails: php version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68426cb74b30832ea0ab2b3a87be3e68