### PR TITLE
Add unit tests for key operations

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,5 +29,7 @@
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
         <env name="MAIL_DRIVER" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
     </php>
 </phpunit>

--- a/tests/Unit/NotaDataTablesEditorTest.php
+++ b/tests/Unit/NotaDataTablesEditorTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace Tests\Unit;
+
+use ATS\DataTables\NotaDataTablesEditor;
+use ATS\Model\Estudiante;
+use ATS\Model\Planilla;
+use Illuminate\Support\Facades\Config;
+use Mockery;
+use Tests\TestCase;
+
+class NotaDataTablesEditorTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_edit_rules_require_id_and_planilla()
+    {
+        $editor = new NotaDataTablesEditor();
+        $estudiante = new Estudiante();
+
+        $rules = $editor->editRules($estudiante);
+        $this->assertArrayHasKey('id', $rules);
+        $this->assertArrayHasKey('planilla_id', $rules);
+    }
+
+    public function test_updating_processes_notas_and_inasistencias()
+    {
+        $editor = new NotaDataTablesEditor();
+
+        $planilla = Mockery::mock(Planilla::class);
+        $editor->updating(new Estudiante(), [
+            'planilla_id' => 1,
+            'notas' => [
+                'data' => [
+                    ['id' => 1, 'cognitivo' => ['id' => 1, 'score' => 4]],
+                    ['id' => 2, 'procedimental' => ['id' => 2, 'score' => 4]],
+                    ['id' => 3, 'actitudinal' => ['id' => 3, 'score' => 4]]
+                ]
+            ],
+            'inasistencias' => [
+                'data' => ['id' => 1, 'numero' => 0]
+            ]
+        ]);
+
+        $this->assertTrue(true); // If no exception is thrown, assume success
+    }
+}

--- a/tests/Unit/PlanillaUpdateTest.php
+++ b/tests/Unit/PlanillaUpdateTest.php
@@ -1,0 +1,21 @@
+<?php
+namespace Tests\Unit;
+
+use ATS\Model\Planilla;
+use Tests\TestCase;
+
+class PlanillaUpdateTest extends TestCase
+{
+    public function test_is_load_and_is_edited_helpers()
+    {
+        $planilla = new Planilla(['cargada' => 0, 'modificada' => 0]);
+        $this->assertFalse($planilla->isLoad());
+        $this->assertFalse($planilla->isEdited());
+
+        $planilla->cargada = 1;
+        $planilla->modificada = 1;
+
+        $this->assertTrue($planilla->isLoad());
+        $this->assertTrue($planilla->isEdited());
+    }
+}

--- a/tests/Unit/UserRolesTest.php
+++ b/tests/Unit/UserRolesTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace Tests\Unit;
+
+use ATS\Model\User;
+use Mockery;
+use Tests\TestCase;
+
+class UserRolesTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_is_admin_returns_true_for_admin_role()
+    {
+        $user = new User();
+
+        $mock = Mockery::mock('alias:Bouncer');
+        $mock->shouldReceive('is')->with($user)->andReturn(new class {
+            public function an($role) { return $role === 'admin'; }
+        });
+
+        $this->assertTrue($user->isAdmin());
+    }
+
+    public function test_is_docente_returns_false_when_not_assigned()
+    {
+        $user = new User();
+
+        $mock = Mockery::mock('alias:Bouncer');
+        $mock->shouldReceive('is')->with($user)->andReturn(new class {
+            public function an($role) { return false; }
+        });
+
+        $this->assertFalse($user->isDocente());
+    }
+}

--- a/tests/Unit/VerificadorNotasTest.php
+++ b/tests/Unit/VerificadorNotasTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace Tests\Unit;
+
+use ATS\Clases\Estudiante\VerificadorNotas;
+use ATS\Model\Planilla;
+use ATS\Model\Periodo;
+use Illuminate\Support\Collection;
+use Mockery;
+use Tests\TestCase;
+
+class VerificadorNotasTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_get_periodo_final_returns_final_period()
+    {
+        $planilla = Mockery::mock(Planilla::class);
+
+        $periodo = new Periodo(['id' => 1, 'isFinal' => 1]);
+
+        $mock = Mockery::mock('alias:ATS\\Clases\\CurrentAnio');
+        $mock->shouldReceive('periodos')->once()->andReturn(new Collection([$periodo]));
+
+        $verificador = new VerificadorNotas($planilla);
+        $this->assertSame($periodo, $verificador->getPeriodoFinal());
+    }
+}


### PR DESCRIPTION
## Summary
- configure phpunit for sqlite in-memory testing
- add tests for `VerificadorNotas`
- add tests for DataTables Editor update flow
- test user role helpers
- test Planilla helper methods

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68426cb13ad0832e9307c98da4147d22